### PR TITLE
Added missing argument for FogBugz XML API call for closing a release nu...

### DIFF
--- a/FogBugz7Provider.cs
+++ b/FogBugz7Provider.cs
@@ -427,6 +427,7 @@ namespace Inedo.BuildMasterExtensions.FogBugz
                         "viewFixFor",
                         new Dictionary<string, string>
                         {
+                            { "token", token },
                             { "ixProject", this.CategoryIdFilter[0] },
                             { "sFixFor", releaseNumber }
                         });


### PR DESCRIPTION
...mber.

Added token argument for FogBugz XML API call that retrieves the ID of the FogBugz milestone corresponding to the release number to be closed.
